### PR TITLE
Add github.com to known_hosts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,7 @@ MAINTAINER Baptiste Mathus <batmat@batmat.net>
 RUN useradd --create-home -s /bin/bash user
 WORKDIR /home/user
 USER user
+
+# Known hosts for SSH
+RUN mkdir -p /home/user/.ssh && \
+    echo "github.com,192.30.252.131 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==" >> /home/user/.ssh/known_hosts


### PR DESCRIPTION
Useful when this image is used as a build agent for Jenkins (checking out code from github is a common task)